### PR TITLE
Allow missing hyphenator.

### DIFF
--- a/src/org/daisy/dotify/translator/impl/DummyHyphenator.java
+++ b/src/org/daisy/dotify/translator/impl/DummyHyphenator.java
@@ -1,0 +1,26 @@
+package org.daisy.dotify.translator.impl;
+
+public class DummyHyphenator implements org.daisy.dotify.api.hyphenator.HyphenatorInterface {
+    @Override
+    public String hyphenate(String phrase) {
+        return phrase;
+    }
+
+    @Override
+    public int getBeginLimit() {
+        return 0;
+    }
+
+    @Override
+    public void setBeginLimit(int beginLimit) {
+    }
+
+    @Override
+    public int getEndLimit() {
+        return 0;
+    }
+
+    @Override
+    public void setEndLimit(int endLimit) {
+    }
+}

--- a/src/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilter.java
+++ b/src/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilter.java
@@ -23,6 +23,7 @@ import org.daisy.dotify.api.translator.TranslatableWithContext;
 import org.daisy.dotify.api.translator.TranslationException;
 import org.daisy.dotify.api.translator.TranslatorSpecification;
 import org.daisy.dotify.translator.DefaultMarkerProcessor;
+import org.daisy.dotify.translator.impl.DummyHyphenator;
 import org.liblouis.CompilationException;
 import org.liblouis.DisplayException;
 import org.liblouis.DisplayTable.Fallback;
@@ -233,16 +234,15 @@ class LiblouisBrailleFilter implements BrailleFilter {
 				if (hx == null) {
 					try {
 						hx = hyphenatorFactoryMaker.newHyphenator(locale);
-                        hyphenators.put(locale, hx);
 					} catch (HyphenatorConfigurationException e) {
 						if (LOGGER.isLoggable(Level.WARNING)) {
 							LOGGER.log(Level.WARNING, String.format("Failed to create hyphenator for %s", locale), e);
 						}
+						hx = new DummyHyphenator();
 					}
+                    hyphenators.put(locale, hx);
 				}
-                if (hx != null) {
-                    hyphText = hx.hyphenate(text);
-                }
+                hyphText = hx.hyphenate(text);
 			}
 
 			textB.append(text);

--- a/src/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilter.java
+++ b/src/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilter.java
@@ -240,9 +240,9 @@ class LiblouisBrailleFilter implements BrailleFilter {
 						}
 						hx = new DummyHyphenator();
 					}
-                    hyphenators.put(locale, hx);
+					hyphenators.put(locale, hx);
 				}
-                hyphText = hx.hyphenate(text);
+				hyphText = hx.hyphenate(text);
 			}
 
 			textB.append(text);

--- a/src/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilter.java
+++ b/src/org/daisy/dotify/translator/impl/liblouis/LiblouisBrailleFilter.java
@@ -233,14 +233,16 @@ class LiblouisBrailleFilter implements BrailleFilter {
 				if (hx == null) {
 					try {
 						hx = hyphenatorFactoryMaker.newHyphenator(locale);
+                        hyphenators.put(locale, hx);
 					} catch (HyphenatorConfigurationException e) {
 						if (LOGGER.isLoggable(Level.WARNING)) {
 							LOGGER.log(Level.WARNING, String.format("Failed to create hyphenator for %s", locale), e);
 						}
 					}
-					hyphenators.put(locale, hx);
 				}
-				hyphText = hx.hyphenate(text);
+                if (hx != null) {
+                    hyphText = hx.hyphenate(text);
+                }
 			}
 
 			textB.append(text);


### PR DESCRIPTION
Hi @bertfrees and @PaulRambags

We have noticed that when running some of the defined languages in liblouis the translator crashes because there is no defined hyphenator.

In this pull request, I've added a dummy hyphenator that is added if no hyphenator is defined. In this way, you get a warning that there is no hyphenator, but the book is translated into pef without a crash.

Best regards
Daniel